### PR TITLE
refactor: don't require Open edX for Django apps

### DIFF
--- a/site_config_client/apps.py
+++ b/site_config_client/apps.py
@@ -4,22 +4,25 @@ from django.apps import AppConfig
 
 class SiteConfigApp(AppConfig):
     """
-    Django app configs.
+    Django and Open edX app configs.
     """
     name = 'site_config_client'
     label = 'site_config_client'
     verbose_name = 'Site configuration API client and Open edX plugin.'
 
-
-class OpenedXSiteConfigApp(SiteConfigApp):
-    """
-    Open edX app configs.
-    """
-
     @property
     def plugin_app(self):
+        """
+        Open edX-specific configurations.
+
+        This is not used by Django.
+        """
+        # Import locally to allow non-Open edX use.
         from openedx.core.djangoapps.plugins.constants import (
-    PluginSettings, ProjectType, SettingsType)
+            PluginSettings,
+            ProjectType,
+            SettingsType,
+        )
 
         return {
             PluginSettings.CONFIG: {


### PR DESCRIPTION
Address Anders comment: https://github.com/appsembler/site-configuration-client/pull/7/files#r733610196
