### PR TITLE
enable coverage reports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  tests:
     name: ${{ matrix.tox-env }} - Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
@@ -33,4 +33,45 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox flake8
       - name: Test with tox
-        run: tox -e ${{ matrix.tox-env }}
+        run: |
+          tox -e ${{ matrix.tox-env }}
+          if [ -f .coverage ]; then mv .coverage ".coverage.${{ matrix.python-version }}-${{ matrix.tox-env }}"; fi
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage-data
+          path: "*.coverage.*"
+        if: ${{ startsWith(matrix.tox-env, 'py3') }}
+
+  coverage:
+    name: Combine and check coverage
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          # Use latest, so it understands all syntax.
+          python-version: '3.10'
+
+      - run: python -m pip install --upgrade coverage[toml]
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-data
+
+      - name: 'Combine coverage & fail if it is less than 100%'
+        id: coverage
+        run: |
+          coverage combine
+          coverage html --skip-covered --skip-empty
+          coverage report --fail-under=100
+
+      - name: Upload HTML report if check failed
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: html-report
+          path: htmlcov


### PR DESCRIPTION
Fixes https://github.com/appsembler/site-configuration-client/issues/42 

Native to GitHub without using external tools: https://hynek.me/articles/ditch-codecov-python/


### HTML reports

 - **Question:** How to access coverage reports in the case of failure
 - Answer: Go to the "Checks" section and download the HTML report.