### PR TITLE
add auth headers to requests

### DIFF
--- a/site_config_client/__init__.py
+++ b/site_config_client/__init__.py
@@ -1,3 +1,4 @@
+import json
 import requests
 from typing import Union
 import uuid
@@ -25,7 +26,9 @@ class Client:
         """
         Returns a list of all Sites
         """
-        response = requests.get(self.build_url('v1/site/'))
+        auth_headers = {'Authorization': '{}'.format(self.api_token)}
+        response = requests.get(self.build_url('v1/site/'),
+                                headers=auth_headers)
         if response.status_code == 200:
             return response.json()
         else:
@@ -38,11 +41,9 @@ class Client:
         """
         Returns a list of all active Sites
         """
-        data = {
-            "is_active": "True"
-        }
-        response = requests.get(
-            self.build_url('v1/site/?is_active=True'), data=data)
+        auth_headers = {'Authorization': '{}'.format(self.api_token)}
+        response = requests.get(self.build_url('v1/site/?is_active=True'),
+                                headers=auth_headers)
         if response.status_code == 200:
             return response.json()
         else:
@@ -71,7 +72,9 @@ class Client:
 
         endpoint = 'v1/combined-configuration/backend/{}/{}/'.format(
             site_uuid, status)
-        response = requests.get(self.build_url(endpoint))
+        auth_headers = {'Authorization': '{}'.format(self.api_token)}
+        response = requests.get(self.build_url(endpoint),
+                                headers=auth_headers)
         if response.status_code == 200:
             config = response.json()
         else:
@@ -90,13 +93,10 @@ class Client:
         """
         Returns a single configuration object for Site
         """
-        endpoint = 'v1/configuration/{}/'.format(site_uuid)
-        data = {
-            "type": type,
-            "name": name,
-            "status": status
-        }
-        response = requests.get(self.build_url(endpoint), data=data)
+        endpoint = 'v1/configuration/{}/?type={}&name={}&status={}'.format(site_uuid, type, name, status)
+        auth_headers = {'Authorization': '{}'.format(self.api_token)}
+        response = requests.get(self.build_url(endpoint),
+                                headers=auth_headers)
         if response.status_code == 200:
             return response.json()
         else:
@@ -113,7 +113,11 @@ class Client:
         rollout.
         """
         endpoint = 'v0/configuration-override/{}/'.format(site_uuid)
-        response = requests.put(self.build_url(endpoint), data=configs)
+        auth_headers = {'Authorization': '{}'.format(self.api_token),
+                        'content-type': 'application/json'}
+        response = requests.put(self.build_url(endpoint),
+                                data=json.dumps(configs),
+                                headers=auth_headers)
         if response.status_code == 200:
             return response.json()
         else:

--- a/site_config_client/__init__.py
+++ b/site_config_client/__init__.py
@@ -101,7 +101,7 @@ class Client:
         }
         auth_headers = {'Authorization': 'Token {}'.format(self.api_token)}
         response = requests.get(self.build_url(endpoint),
-                                headers=auth_headers, data=data)
+                                headers=auth_headers, params=data)
         if response.status_code == 200:
             return response.json()
         else:

--- a/site_config_client/__init__.py
+++ b/site_config_client/__init__.py
@@ -26,7 +26,7 @@ class Client:
         """
         Returns a list of all Sites
         """
-        auth_headers = {'Authorization': '{}'.format(self.api_token)}
+        auth_headers = {'Authorization': 'Token {}'.format(self.api_token)}
         response = requests.get(self.build_url('v1/site/'),
                                 headers=auth_headers)
         if response.status_code == 200:
@@ -41,7 +41,7 @@ class Client:
         """
         Returns a list of all active Sites
         """
-        auth_headers = {'Authorization': '{}'.format(self.api_token)}
+        auth_headers = {'Authorization': 'Token {}'.format(self.api_token)}
         response = requests.get(self.build_url('v1/site/?is_active=True'),
                                 headers=auth_headers)
         if response.status_code == 200:
@@ -72,7 +72,7 @@ class Client:
 
         endpoint = 'v1/combined-configuration/backend/{}/{}/'.format(
             site_uuid, status)
-        auth_headers = {'Authorization': '{}'.format(self.api_token)}
+        auth_headers = {'Authorization': 'Token {}'.format(self.api_token)}
         response = requests.get(self.build_url(endpoint),
                                 headers=auth_headers)
         if response.status_code == 200:
@@ -93,10 +93,15 @@ class Client:
         """
         Returns a single configuration object for Site
         """
-        endpoint = 'v1/configuration/{}/?type={}&name={}&status={}'.format(site_uuid, type, name, status)
-        auth_headers = {'Authorization': '{}'.format(self.api_token)}
+        endpoint = 'v1/configuration/{}/'.format(site_uuid)
+        data = {
+            "type": type,
+            "name": name,
+            "status": status
+        }
+        auth_headers = {'Authorization': 'Token {}'.format(self.api_token)}
         response = requests.get(self.build_url(endpoint),
-                                headers=auth_headers)
+                                headers=auth_headers, data=data)
         if response.status_code == 200:
             return response.json()
         else:
@@ -113,7 +118,7 @@ class Client:
         rollout.
         """
         endpoint = 'v0/configuration-override/{}/'.format(site_uuid)
-        auth_headers = {'Authorization': '{}'.format(self.api_token),
+        auth_headers = {'Authorization': 'Token {}'.format(self.api_token),
                         'content-type': 'application/json'}
         response = requests.put(self.build_url(endpoint),
                                 data=json.dumps(configs),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -114,10 +114,16 @@ def test_url(site_config_client):
 
 
 def test_list_sites(site_config_client, requests_mock):
+    headers = {'Authorization': '{}'.
+               format(site_config_client.api_token)}
+
     site_path = "http://service/v1/site/"
-    requests_mock.get(site_path, json=SITES, status_code=200)
+    requests_mock.get(site_path, json=SITES, headers=headers, status_code=200)
     response_sites = site_config_client.list_sites()
     assert response_sites == SITES
+    history = requests_mock.request_history[0]
+    assert history.headers.get("Authorization") == "some-token", (
+        "API Token passed in Authorization header")
 
 
 def test_list_sites_with_error(site_config_client, requests_mock):
@@ -129,10 +135,17 @@ def test_list_sites_with_error(site_config_client, requests_mock):
 
 
 def test_list_active_sites(site_config_client, requests_mock):
+    headers = {'Authorization': '{}'.
+               format(site_config_client.api_token)}
+
     active_sites_path = "http://service/v1/site/?is_active=True"
-    requests_mock.get(active_sites_path, json=SITES, status_code=200)
+    requests_mock.get(active_sites_path, json=SITES, headers=headers,
+                      status_code=200)
     response_active_sites = site_config_client.list_active_sites()
     assert response_active_sites == SITES
+    history = requests_mock.request_history[0]
+    assert history.headers.get("Authorization") == "some-token", (
+        "API Token passed in Authorization header")
 
 
 def test_list_active_sites_error(site_config_client, requests_mock):
@@ -144,15 +157,21 @@ def test_list_active_sites_error(site_config_client, requests_mock):
 
 
 def test_get_backend_configs(requests_mock, site_config_client):
+    headers = {'Authorization': '{}'.
+               format(site_config_client.api_token)}
+
     backend_draft_configs_path = (
         'http://service/v1/combined-configuration/backend/{}/draft/'
         .format(PARAMS['uuid']))
     requests_mock.get(backend_draft_configs_path,
-                      json=CONFIGS, status_code=200)
+                      json=CONFIGS, headers=headers, status_code=200)
     response_configs = site_config_client.get_backend_configs(
         site_uuid=PARAMS['uuid'], status='draft')
     assert response_configs == CONFIGS, (
         'Neither cache nor google cloud storage configured')
+    history = requests_mock.request_history[0]
+    assert history.headers.get("Authorization") == "some-token", (
+        "API Token passed in Authorization header")
 
 
 def test_get_backend_configs_error(requests_mock, site_config_client):
@@ -193,15 +212,21 @@ def test_get_backend_configs_cache(requests_mock, site_config_client):
 
 
 def test_get_config(requests_mock, site_config_client):
+    headers = {'Authorization': '{}'.
+               format(site_config_client.api_token)}
+
     config_path = "http://service/v1/configuration/{}/".format(PARAMS['uuid'])
-    requests_mock.get(config_path,
-                      json=SINGLE_CONFIG, status_code=200)
+    requests_mock.get(config_path, json=SINGLE_CONFIG, headers=headers,
+                      status_code=200)
     response_configs = site_config_client.get_config(
         site_uuid=PARAMS['uuid'],
         type="setting",
         name="PLATFORM_NAME",
         status="live")
     assert response_configs == SINGLE_CONFIG
+    history = requests_mock.request_history[0]
+    assert history.headers.get("Authorization") == "some-token", (
+        "API Token passed in Authorization header")
 
 
 def test_get_config_error(requests_mock, site_config_client):
@@ -219,16 +244,23 @@ def test_get_config_error(requests_mock, site_config_client):
 
 
 def test_override_configs(requests_mock, site_config_client):
+    headers = {'Authorization': '{}'.
+               format(site_config_client.api_token)}
+
     override_path = (
         "http://service/v0/configuration-override/{}/"
         .format(PARAMS['uuid']))
     success_response = {
         "developer_message": "Configurations has been overriden successfully."
         }
-    requests_mock.put(override_path, json=success_response, status_code=200)
+    requests_mock.put(override_path, json=success_response,
+                      headers=headers, status_code=200)
     override_response = site_config_client.override_configs(
         site_uuid=PARAMS['uuid'], configs=OVERRIDE_CONFIGS)
     assert override_response == success_response
+    history = requests_mock.request_history[0]
+    assert history.headers.get("Authorization") == "some-token", (
+        "API Token passed in Authorization header")
 
 
 def test_override_configs_error(requests_mock, site_config_client):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -113,6 +113,10 @@ def test_url(site_config_client):
     assert site_endpoint == "http://service/v1/site/"
 
 
+def test_client_has_token(site_config_client):
+    assert site_config_client.api_token, 'Client should have an API token'
+
+
 def test_list_sites(site_config_client, requests_mock):
     headers = {'Authorization': '{}'.
                format(site_config_client.api_token)}
@@ -122,7 +126,7 @@ def test_list_sites(site_config_client, requests_mock):
     response_sites = site_config_client.list_sites()
     assert response_sites == SITES
     history = requests_mock.request_history[0]
-    assert history.headers.get("Authorization") == "some-token", (
+    assert history.headers.get("Authorization") == "Token some-token", (
         "API Token passed in Authorization header")
 
 
@@ -144,7 +148,7 @@ def test_list_active_sites(site_config_client, requests_mock):
     response_active_sites = site_config_client.list_active_sites()
     assert response_active_sites == SITES
     history = requests_mock.request_history[0]
-    assert history.headers.get("Authorization") == "some-token", (
+    assert history.headers.get("Authorization") == "Token some-token", (
         "API Token passed in Authorization header")
 
 
@@ -170,7 +174,7 @@ def test_get_backend_configs(requests_mock, site_config_client):
     assert response_configs == CONFIGS, (
         'Neither cache nor google cloud storage configured')
     history = requests_mock.request_history[0]
-    assert history.headers.get("Authorization") == "some-token", (
+    assert history.headers.get("Authorization") == "Token some-token", (
         "API Token passed in Authorization header")
 
 
@@ -225,7 +229,7 @@ def test_get_config(requests_mock, site_config_client):
         status="live")
     assert response_configs == SINGLE_CONFIG
     history = requests_mock.request_history[0]
-    assert history.headers.get("Authorization") == "some-token", (
+    assert history.headers.get("Authorization") == "Token some-token", (
         "API Token passed in Authorization header")
 
 
@@ -259,7 +263,7 @@ def test_override_configs(requests_mock, site_config_client):
         site_uuid=PARAMS['uuid'], configs=OVERRIDE_CONFIGS)
     assert override_response == success_response
     history = requests_mock.request_history[0]
-    assert history.headers.get("Authorization") == "some-token", (
+    assert history.headers.get("Authorization") == "Token some-token", (
         "API Token passed in Authorization header")
 
 


### PR DESCRIPTION
## Add Authorization Headers

When I was testing the `Client` methods via our GAE base URL, I noticed that the methods were returning 400 errors because the api tokens were missing from the requests.
This PR adds the Client API Token to the Authorization headers and passes the headers to each requests.
