### PR TITLE
fix `plugin_app` error in Open edX make it a dictionary again

### DIFF
--- a/site_config_client/apps.py
+++ b/site_config_client/apps.py
@@ -1,5 +1,15 @@
 from django.apps import AppConfig
 
+try:
+    from openedx.core.djangoapps.plugins.constants import (
+        PluginSettings,
+        ProjectType,
+        SettingsType,
+    )
+    OPENEDX_ENVIRONMENT = True
+except ImportError:
+    OPENEDX_ENVIRONMENT = False
+
 
 class SiteConfigApp(AppConfig):
     """
@@ -9,26 +19,15 @@ class SiteConfigApp(AppConfig):
     label = 'site_config_client'
     verbose_name = 'Site configuration API client and Open edX plugin.'
 
-    @property
-    def plugin_app(self):
-        """
-        Open edX-specific configurations.
-        This is not used by Django.
-        """
-        # Import locally to allow non-Open edX use.
-        from openedx.core.djangoapps.plugins.constants import (
-            PluginSettings,
-            ProjectType,
-            SettingsType,
-        )
-
-        return {
+    if OPENEDX_ENVIRONMENT:
+        # Open edX-specific configurations. This is not used by Django-only environment.
+        plugin_app = {
             PluginSettings.CONFIG: {
                 ProjectType.LMS: {
                     SettingsType.PRODUCTION: {
                         PluginSettings.RELATIVE_PATH: 'settings.production'},
                     SettingsType.COMMON: {
                         PluginSettings.RELATIVE_PATH: 'settings.common'},
-                }
+                },
             },
         }

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -3,9 +3,15 @@ Test SiteConfigApp
 """
 import pytest
 
+try:
+    import openedx  # noqa
+    OPENEDX_ENVIRONMENT = True
+except ImportError:
+    OPENEDX_ENVIRONMENT = False
+
 
 @pytest.mark.openedx
-def test_plugin_config():
+def test_plugin_config_openedx():
     """
     Check for syntax or other severe errors in SiteConfigApp.plugin_app
     """
@@ -13,4 +19,17 @@ def test_plugin_config():
     from site_config_client import apps
 
     config = apps.SiteConfigApp('siteconfig', apps)
-    assert type(config.plugin_app) == dict
+    assert type(config.plugin_app) == dict, 'Should have Open edX configs.'
+
+
+@pytest.mark.django
+@pytest.mark.skipif(OPENEDX_ENVIRONMENT, reason='Should not run if `openedx` is available')
+def test_plugin_config_django():
+    """
+    Check for syntax or other severe errors in SiteConfigApp.plugin_app
+    """
+    # Local import to avoid test failures for non-django tests
+    from site_config_client import apps
+
+    config = apps.SiteConfigApp('siteconfig', apps)
+    assert not getattr(config, 'plugin_app', None), 'Plugin app should only be available in Open edX environment.'


### PR DESCRIPTION
Aparently Open edX can't work with `@property` and expects a regular dictionary. This PR fixes the error below in Open edX:

```
AttributeError: 'property' object has no attribute 'get'
```