### PR TITLE
 Make GCP bucket optional in Open edX

### DIFF
--- a/site_config_client/openedx/settings/production.py
+++ b/site_config_client/openedx/settings/production.py
@@ -1,10 +1,13 @@
 """
 Production settings for the Open edX
 """
+import logging
 
 from site_config_client import Client
 from site_config_client.django_cache import DjangoCache
-from site_config_client.google_cloud_storage import GoogleCloudStorage
+
+
+log = logging.getLogger(__name__)
 
 
 def plugin_settings(settings):
@@ -12,15 +15,30 @@ def plugin_settings(settings):
     Production and devstack settings for Site Configuration API Client.
     """
 
-    read_only_storage = GoogleCloudStorage(
-        settings.SITE_CONFIG_READ_ONLY_BUCKET)
+    bucket_name = getattr(settings, 'SITE_CONFIG_READ_ONLY_BUCKET', None)
+    read_only_storage = None
+
+    if bucket_name:
+        # Google Cloud Storage is optional and used for service reliability
+        from site_config_client.google_cloud_storage import GoogleCloudStorage
+        read_only_storage = GoogleCloudStorage(
+            bucket_name=settings.SITE_CONFIG_READ_ONLY_BUCKET,
+        )
+    else:
+        log.warning('Not initializing Google storage bucket due to missing settings parameter.')
+
     cache = DjangoCache(
         cache_name=getattr(settings, 'SITE_CONFIG_CACHE_NAME', 'default'),
         cache_timeout=getattr(settings, 'SITE_CONFIG_CACHE_TIMEOUT', None),
     )
-    settings.SITE_CONFIG_CLIENT = Client(
-        base_url=settings.SITE_CONFIG_BASE_URL,
-        api_token=settings.SITE_CONFIG_API_TOKEN,
-        read_only_storage=read_only_storage,
-        cache=cache,
-    )
+
+    base_url = getattr(settings, 'SITE_CONFIG_BASE_URL', None)
+    if base_url:
+        settings.SITE_CONFIG_CLIENT = Client(
+            base_url=settings.SITE_CONFIG_BASE_URL,
+            api_token=settings.SITE_CONFIG_API_TOKEN,
+            read_only_storage=read_only_storage,
+            cache=cache,
+        )
+    else:
+        log.warning('Not initializing SITE_CONFIG_CLIENT due to missing parameter.')

--- a/tests/test_plugin_settings.py
+++ b/tests/test_plugin_settings.py
@@ -2,9 +2,9 @@ import mock
 import pytest
 
 
-@mock.patch('google.cloud.storage.Client')
+@mock.patch('google.cloud.storage.Client', mock.Mock())
 @pytest.mark.openedx
-def test_plugin_production_settings(client):
+def test_plugin_production_settings():
     # Local import to avoid test failures for non-openedx tests
     from site_config_client.openedx.settings.production import plugin_settings
 
@@ -23,6 +23,46 @@ def test_plugin_production_settings(client):
     assert settings.SITE_CONFIG_CLIENT.read_only_storage, (
         'GCP storage is initialized')
     assert settings.SITE_CONFIF_CLIENT.cache, 'Cache is initialized'
+
+
+@mock.patch('google.cloud.storage.Client', mock.Mock())
+@pytest.mark.openedx
+def test_plugin_production_settings_no_gcp(caplog):
+    # Local import to avoid test failures for non-openedx tests
+    from site_config_client.openedx.settings.production import plugin_settings
+
+    settings = mock.Mock(
+        SITE_CONFIG_CLIENT=None,
+        SITE_CONFIG_CACHE_NAME='default',
+        SITE_CONFIG_CACHE_TIMEOUT=3600,
+        SITE_CONFIG_BASE_URL="http://service",
+        SITE_CONFIG_API_TOKEN="some-token",
+        SITE_CONFIG_READ_ONLY_BUCKET=None,
+    )
+
+    plugin_settings(settings)
+
+    assert settings.SITE_CONFIG_CLIENT, 'Client should be initialized'
+    assert not settings.SITE_CONFIG_CLIENT.read_only_storage, (
+        'GCP storage should not be initialized because SITE_CONFIG_READ_ONLY_BUCKET is not provided')
+    assert settings.SITE_CONFIF_CLIENT.cache, 'Cache is initialized'
+
+    assert 'Not initializing Google storage' in caplog.text
+
+
+@pytest.mark.openedx
+def test_plugin_production_settings_no_client(caplog):
+    # Local import to avoid test failures for non-openedx tests
+    from site_config_client.openedx.settings.production import plugin_settings
+
+    settings = mock.Mock(
+        SITE_CONFIG_BASE_URL=None,
+        SITE_CONFIG_READ_ONLY_BUCKET=None,
+    )
+    plugin_settings(settings)
+    assert settings.SITE_CONFIG_CLIENT, 'Client should not be initialized due to missing SITE_CONFIG_BASE_URL'
+
+    assert 'Not initializing SITE_CONFIG_CLIENT' in caplog.text
 
 
 @pytest.mark.openedx


### PR DESCRIPTION
This makes it possible to be used in Open edX without GCP dependency.

### TODO
 - [x] Get it reviewed
 - [x] Get the #33 pull request merged
 - [x] Change base to `main` and merge