### PR TITLE
Misc fixes to prep for `models.py` and migrations

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -13,7 +13,7 @@ PWD = os.path.abspath(os.path.dirname(__file__))
 if __name__ == '__main__':
     os.environ.setdefault(
         'DJANGO_SETTINGS_MODULE',
-        'site_config_client.test_settings'
+        'test_settings'
     )
     sys.path.append(PWD)
     try:

--- a/test_settings.py
+++ b/test_settings.py
@@ -3,3 +3,16 @@ Empty pytest settings.
 """
 
 SECRET_KEY = 'dummy secret key'  # nosec
+
+INSTALLED_APPS = [
+    'site_config_client',
+]
+
+FEATURES = {}
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -36,3 +36,12 @@ deps =
     bandit==1.7.1
 commands =
     bandit -c bandit.yaml -r site_config_client
+
+
+[testenv:shell-django]
+# Run arbitrary commands for migrations and otherwise e.g.
+#     $ tox -e shell-django -- python manage.py makemigrations site_config_client
+
+basepython = python3
+commands =
+    {posargs}


### PR DESCRIPTION
 - fix manage.py default settings path
 - `tox.ini`: allow running arbirtary django manage commands
 - `test_settings.py`: prep for migrations and models

