### PR TITLE
openedx.adapter: convert to a single class

### DIFF
--- a/site_config_client/openedx/adapter.py
+++ b/site_config_client/openedx/adapter.py
@@ -6,74 +6,44 @@ from django.conf import settings
 AMC_V1_STRUCTURE_VERSION = 'amc-v1'
 
 
-def get_backend_config(site_uuid, status='live'):
-    client = settings.SITE_CONFIG_CLIENT
-    return client.get_backend_configs(site_uuid, status)
+class SiteConfigAdapter:
+    """
+    Adapter for Open edX translates the values in a format that Open edX can use.
+    """
 
+    backend_configs = None
 
-def get_value(site_uuid, name, default=None):
-    '''
-    Returns config value for config type `setting`
+    def __init__(self, site_uuid):
+        self.site_uuid = site_uuid
 
-    ** STEPS **
-    1. Config retrieved via the Client.get_backend_configs()
-       Example Response:
-            {
-                "site": {...},
-                "status": "live",
-                "configuration": {...}
-                "integration": {...},
-                "secret": {...},
-                "admin": {...}
-            }
+    def get_backend_configs(self, status='live'):
+        if not self.backend_configs:
+            client = settings.SITE_CONFIG_CLIENT
+            self.backend_configs = client.get_backend_configs(self.site_uuid, status)
+        return self.backend_configs
 
-    2. Get `configuration` field from response
-        Example `configuration`:
-            {
-                "css": {
-                    "selected_font “": "lato",
-                    "text_color": "#0a0a0a",
-                    "header_logo_height": "110",
-                },
-                "page": {},
-                "setting": {
-                    "PLATFORM_NAME": "My New Platform Name!",
-                    "site_name": "My site name",
-                    "footer_copyright_text": "© Appsembler 2021. All rights reserved.1",
-                    "display_footer_powered_by": "false",
-                    }
-                }
-            }
+    def get_value(self, name, default=None):
+        """
+        Returns config value for config type `setting`.
+        """
+        site_values = self.get_site_values()
+        return site_values.get(name, default)
 
-    3. Return values for configuration['setting']
-        Example:
-            {
-                "PLATFORM_NAME": "My New Platform Name!",
-                "site_name": "My site name",
-                "footer_copyright_text": "© Appsembler 2021. All rights reserved.1",
-                "display_footer_powered_by": "false",
-            }
+    def get_site_values(self):
+        config = self.get_backend_configs()['configuration']
+        openedx_compatible_json = config['setting']
 
+        # TODO: Update our segment classes to use secrets and remove this line
+        openedx_compatible_json['SEGMENT_KEY'] = config['secret'].get('SEGMENT_KEY')
+        return openedx_compatible_json
 
-    '''
-    config = get_backend_config(site_uuid)['configuration']
-    openedx_compatible_json = config['setting']
+    def get_amc_v1_theme_css_variables(self):
+        config = self.get_backend_configs()['configuration']
+        openedx_theme_compatible_css_vars = config['css']
+        # NOTE: This function assumes that all varialbes are compativle with v1 theme.
+        return openedx_theme_compatible_css_vars
 
-    # TODO: Update out segment classes to use secrets and remove this line
-    openedx_compatible_json['SEGMENT_KEY'] = config['secret'].get('SEGMENT_KEY')
-
-    return openedx_compatible_json.get(name, default)
-
-
-def get_amc_v1_theme_css_variables(site_uuid):
-    config = get_backend_config(site_uuid)['configuration']
-
-    openedx_theme_compatible_css_vars = config['css']
-    # NOTE: This function assumes that all varialbes are compativle with v1 theme.
-    return openedx_theme_compatible_css_vars
-
-
-def get_amc_v1_page(site_uuid, page_name):
-    config = get_backend_config(site_uuid)['configuration']
-    openedx_theme_compatible_page_vars = config['page'][page_name]
-    return openedx_theme_compatible_page_vars
+    def get_amc_v1_page(self, page_name):
+        config = self.get_backend_configs()['configuration']
+        openedx_theme_compatible_page_vars = config['page'][page_name]
+        return openedx_theme_compatible_page_vars

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -53,21 +53,21 @@ def test_adapater(settings):
     and test the return values of:
      `get_value`,  `get_amc_v1_theme_css_variables`, `get_amc_v1_page`
     '''
-    from site_config_client.openedx import adapter
-
-    uuid = "77d4ee4e-6888-4965"
+    from site_config_client.openedx.adapter import SiteConfigAdapter
 
     mock = Mock()
     mock.get_backend_configs.return_value = CONFIGS
     settings.SITE_CONFIG_CLIENT = mock
-    assert adapter.get_backend_config(uuid) == CONFIGS
+    adapter = SiteConfigAdapter("77d4ee4e-6888-4965")
 
-    setting_platform_name = adapter.get_value(uuid, 'PLATFORM_NAME', None)
+    assert adapter.get_backend_configs() == CONFIGS
+
+    setting_platform_name = adapter.get_value('PLATFORM_NAME', None)
     assert setting_platform_name == CONFIGS['configuration']['setting']['PLATFORM_NAME']
-    assert adapter.get_value(uuid, 'SEGMENT_KEY') == 'so secret'
+    assert adapter.get_value('SEGMENT_KEY') == 'so secret'
 
-    css_vars = adapter.get_amc_v1_theme_css_variables(uuid)
+    css_vars = adapter.get_amc_v1_theme_css_variables()
     assert css_vars == CONFIGS['configuration']['css']
 
-    privacy_page_vars = adapter.get_amc_v1_page(uuid, 'privacy')
+    privacy_page_vars = adapter.get_amc_v1_page('privacy')
     assert privacy_page_vars == CONFIGS['configuration']['page']['privacy']


### PR DESCRIPTION
mostly a Developer Experience change for both: 

 - easier import from open edx, and
 - caching the adapter result for later use in Open edX

See: https://github.com/appsembler/edx-platform/pull/1049
