### PR TITLE
 `get_amc_v1_page` accepts `default` parameter

### DIFF
--- a/site_config_client/openedx/adapter.py
+++ b/site_config_client/openedx/adapter.py
@@ -43,7 +43,7 @@ class SiteConfigAdapter:
         # NOTE: This function assumes that all varialbes are compativle with v1 theme.
         return openedx_theme_compatible_css_vars
 
-    def get_amc_v1_page(self, page_name):
+    def get_amc_v1_page(self, page_name, default=None):
         config = self.get_backend_configs()['configuration']
-        openedx_theme_compatible_page_vars = config['page'][page_name]
-        return openedx_theme_compatible_page_vars
+        openedx_theme_compatible_page_content = config['page'].get(page_name, default)
+        return openedx_theme_compatible_page_content

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -71,3 +71,8 @@ def test_adapater(settings):
 
     privacy_page_vars = adapter.get_amc_v1_page('privacy')
     assert privacy_page_vars == CONFIGS['configuration']['page']['privacy']
+
+    assert adapter.get_amc_v1_page('non_existent') is None, 'Should default to None'
+    assert adapter.get_amc_v1_page('non_existent', {'title': 'default'}) == {
+        'title': 'default',
+    }, 'Should has a default'


### PR DESCRIPTION
RED-2511.

Compatibility with theme requirements.