### PR TITLE
Return AMC v1 compatible sass as list

### DIFF
--- a/site_config_client/openedx/adapter.py
+++ b/site_config_client/openedx/adapter.py
@@ -38,9 +38,21 @@ class SiteConfigAdapter:
         return openedx_compatible_json
 
     def get_amc_v1_theme_css_variables(self):
+        """
+        Returns an Open edX AMC v1 theme compatible sass variables.
+
+        Note: This function assumes that all variables are compatible with v1 theme.
+        """
         config = self.get_backend_configs()['configuration']
-        openedx_theme_compatible_css_vars = config['css']
-        # NOTE: This function assumes that all varialbes are compativle with v1 theme.
+
+        # Imitates the values in edX's SiteConfiguration sass_variables
+        openedx_theme_compatible_css_vars = [
+            # Note: The usual AMC produced format is key --> [value, default]
+            #       The second value is mostly unused by Open edX can be
+            #       set as [value, default].
+            [key, val]
+            for key, val in config['css'].items()
+        ]
         return openedx_theme_compatible_css_vars
 
     def get_amc_v1_page(self, page_name, default=None):

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -3,6 +3,7 @@ Tests for adapter
 """
 import pytest
 from unittest.mock import Mock
+from collections import OrderedDict
 
 
 CONFIGS = {
@@ -11,13 +12,16 @@ CONFIGS = {
     },
     "status": "live",
     "configuration": {
-        "css": {
-            "selected_font": "lato",
-            "text_color": "#0a0a0a",
-            "header_logo_height": "110",
-            "header_buttons_color": "#164be0",
-            "header_font_size": "17",
-        },
+        "css": OrderedDict(
+            # Just like a normal dict, but makes tests less flaky
+            (
+                ("selected_font", ["lato", "lato"]),
+                ("text_color", ["#0a0a0a", "#0a0a0a"]),
+                ("header_logo_height", ["110", "110"]),
+                ("header_buttons_color", ["#164be0", "#164be0"]),
+                ("header_font_size", ["17", "17"]),
+            )
+        ),
         "page": {
             "course-card": "course-tile-01",
             "privacy": {
@@ -67,7 +71,14 @@ def test_adapater(settings):
     assert adapter.get_value('SEGMENT_KEY') == 'so secret'
 
     css_vars = adapter.get_amc_v1_theme_css_variables()
-    assert css_vars == CONFIGS['configuration']['css']
+    # This change is temporary til we migrate off AMC and its edx-customers-theme
+    assert css_vars == [
+        ["selected_font", ["lato", "lato"]],
+        ["text_color", ["#0a0a0a", "#0a0a0a"]],
+        ["header_logo_height", ["110", "110"]],
+        ["header_buttons_color", ["#164be0", "#164be0"]],
+        ["header_font_size", ["17", "17"]],
+    ], 'get_amc_v1_theme_css_variables should return AMC-like variables'
 
     privacy_page_vars = adapter.get_amc_v1_page('privacy')
     assert privacy_page_vars == CONFIGS['configuration']['page']['privacy']


### PR DESCRIPTION
Returning the dict as-is means that Open edX needs to worry about converting back into list, which is a concern of the adapter and not Open edX.

 - Enables: https://github.com/appsembler/edx-platform/pull/1062