### PR TITLE
fix: requests timeout should not be a tuple

### DIFF
--- a/site_config_client/__init__.py
+++ b/site_config_client/__init__.py
@@ -16,7 +16,7 @@ class Client:
         self.api_token = api_token
         self.read_only_storage = read_only_storage
         self.cache = cache
-        self.request_timeout = request_timeout,
+        self.request_timeout = request_timeout
 
     def request(self, method, url_path, success_status_code=200, **kwargs):
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -92,11 +92,13 @@ def test_client():
     bucket = "http://storage.googleapis.com/appsembler/site_config"
     c = Client(base_url=base,
                api_token=token,
-               read_only_storage=bucket)
+               read_only_storage=bucket,
+               request_timeout=100,)
 
     assert c.base_url == base
     assert c.api_token == token
     assert c.read_only_storage == bucket
+    assert c.request_timeout == 100, 'should not be a tuple'
 
 
 @pytest.fixture


### PR DESCRIPTION
`requests_mock` is apparently not verifying the `timeout` parameter.