### PR TITLE
run bandit with python3 explicitly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
 
 
 [testenv:bandit]
+basepython = python3
 deps =
     bandit==1.7.1
 commands =


### PR DESCRIPTION
regardless of the system's default python