### PR TITLE
automate pip package publishing on release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,33 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: pip package
+
+on:
+  pull_request:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package for GitHub releases
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      if: ${{ startsWith(github.ref, 'refs/tags') }}
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- Note: Update the `Unreleased link` after adding a new release -->
+
+## [Unreleased](https://github.com/appsembler/tahoe-sites/compare/v0.1.2...HEAD)
+
+## [0.1.2](https://github.com/appsembler/site-configuration-client/compare/v0.1.1...v0.1.2) - 2022-03-16
+ - publish to pypi
+ - starting changelog
+
+## [0.1.1](https://github.com/appsembler/site-configuration-client/commits/v0.1.1) - 2022-03-16
+ - First GitHub release. No pypi release yet.
+
+## 0.1
+ - Initial release. No GitHub release yet.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='site-configuration-client',
-    version='0.1.1',
+    version='0.1.2',
     description='Python client library for Site Configuration API',
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
I've got mixed feelings about releasing this semi-closed source package to pypi but I'll do it anyway.

### TODO
 - [ ] publish to GitHub
 - [ ] follow https://appsembler.atlassian.net/wiki/spaces/ED/pages/2119237766/Setup+PyPI+publishing+workflow+via+GitHub+Actions

closes https://github.com/appsembler/site-configuration-client/issues/52