### PR TITLE
add open edx api to be used for other packages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Note: Update the `Unreleased link` after adding a new release -->
 
-## [Unreleased](https://github.com/appsembler/tahoe-sites/compare/v0.1.3...HEAD)
+## [Unreleased](https://github.com/appsembler/tahoe-sites/compare/v0.1.4...HEAD)
+
+## [0.1.3](https://github.com/appsembler/site-configuration-client/compare/v0.1.3...v0.1.4) - 2022-03-23
+ - added `openedx.api` for getting individual values for the current site
 
 ## [0.1.3](https://github.com/appsembler/site-configuration-client/compare/v0.1.2...v0.1.3) - 2022-03-17
  - added enable_feature_for_site feature helper

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='site-configuration-client',
-    version='0.1.3',
+    version='0.1.4',
     description='Python client library for Site Configuration API',
     classifiers=[
         "Intended Audience :: Developers",

--- a/site_config_client/openedx/api.py
+++ b/site_config_client/openedx/api.py
@@ -1,0 +1,76 @@
+"""
+External Open edX Python API helpers goes here.
+
+### API Contract:
+ * Those APIs should be stable and abstract internal changes.
+
+ * Non-stable and internal APIs should be placed in other modules.
+
+ * The parameters of existing functions should change in a backward compatible way:
+   - No parameters should be removed from the function
+   - New parameters should have safe defaults
+ * For breaking changes, new functions should be created
+"""
+
+try:
+    from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+except ImportError:
+    # Silence the initial import error, but runtime errors will occur in tests and non-Open edX environments.
+    # In tests, `configuration_helpers` can be mocked.
+    pass
+
+
+def get_current_configuration():
+    """
+    Gets current site configuration.
+    """
+    return configuration_helpers.get_current_site_configuration()
+
+
+def get_admin_value(name, default=None, site_configuration=None):
+    """
+    Get `admin` setting from the site configuration service.
+
+    Proxy for `site_configuration.get_admin_setting` until site_configuration is deprecated.
+    """
+    if not site_configuration:
+        site_configuration = get_current_configuration()
+
+    return site_configuration.get_admin_setting(name, default)
+
+
+def get_secret_value(name, default=None, site_configuration=None):
+    """
+    Get `secret` setting from the site configuration service.
+
+    Proxy for `site_configuration.get_secret_value` until site_configuration is deprecated.
+    """
+
+    if not site_configuration:
+        site_configuration = get_current_configuration()
+
+    return site_configuration.get_secret_value(name, default)
+
+
+def get_setting_value(name, default=None, site_configuration=None):
+    """
+    Get `setting` setting from the site configuration service.
+
+    Proxy for `site_configuration.get_value` until site_configuration is deprecated.
+    """
+    if not site_configuration:
+        site_configuration = get_current_configuration()
+
+    return site_configuration.get_value(name, default)
+
+
+def get_page_value(name, default=None, site_configuration=None):
+    """
+    Get `page` setting from the site configuration service.
+
+    Proxy for `site_configuration.get_page_content` until site_configuration is deprecated.
+    """
+    if not site_configuration:
+        site_configuration = get_current_configuration()
+
+    return site_configuration.get_page_content(name, default)

--- a/site_config_client/openedx/test_helpers.py
+++ b/site_config_client/openedx/test_helpers.py
@@ -1,0 +1,18 @@
+"""
+Test helpers for other packages to override testers.
+"""
+
+from unittest.mock import patch, Mock
+
+
+def override_site_config(config_type, **config_overrides):
+    """
+    Override site config settings for a specific type of configuration.
+    """
+    def overrider_for_get_value_of_type(name, default=None, site_configuration=None):
+        return config_overrides.get(name, default)
+
+    return patch(
+        'site_config_client.openedx.api.get_{type}_value'.format(type=config_type),
+        Mock(side_effect=overrider_for_get_value_of_type),
+    )

--- a/tests/test_openedx_api.py
+++ b/tests/test_openedx_api.py
@@ -1,0 +1,77 @@
+"""
+Tests for the openedx.api module.
+"""
+from unittest.mock import patch, Mock
+
+import pytest
+
+try:
+    from site_config_client.openedx import api as openedx_api
+except ImportError:
+    # Silent import failures for non-Open edX environments.
+    pass
+
+
+def with_current_configs(current_config):
+    """
+    @patch `get_current_site_configuration()`
+    """
+    configuration_helpers = Mock()
+    configuration_helpers.get_current_site_configuration.return_value = current_config
+    return patch(
+        'site_config_client.openedx.api.configuration_helpers',
+        configuration_helpers,
+        create=True,
+    )
+
+
+@pytest.mark.openedx
+def test_get_admin_value():
+    """
+    Test `get_admin_value()` helper for `admin` type of configurations.
+    """
+    current_config = Mock()
+    current_config.get_admin_setting.return_value = 'password'
+    with with_current_configs(current_config):
+        admin_value = openedx_api.get_admin_value('IDP_CLIENT', 'default-client')
+    assert admin_value == 'password'
+    current_config.get_admin_setting.assert_called_with('IDP_CLIENT', 'default-client')
+
+
+@pytest.mark.openedx
+def test_get_secret_value():
+    """
+    Test `get_secret_value()` helper for `secret` type of configurations.
+    """
+    current_config = Mock()
+    current_config.get_secret_value.return_value = 'password'
+    with with_current_configs(current_config):
+        secret_value = openedx_api.get_secret_value('EMAIL_PASSWORD', 'default-pass')
+    assert secret_value == 'password'
+    current_config.get_secret_value.assert_called_with('EMAIL_PASSWORD', 'default-pass')
+
+
+@pytest.mark.openedx
+def test_get_setting_value():
+    """
+    Test `get_setting_value()` helper for `setting` type of configurations.
+    """
+    current_config = Mock()
+    current_config.get_value.return_value = 'pre-defined-site.com'
+    with with_current_configs(current_config):
+        setting = openedx_api.get_setting_value('SITE_NAME', 'defaultsite.com')
+    assert setting == 'pre-defined-site.com'
+    current_config.get_value.assert_called_with('SITE_NAME', 'defaultsite.com')
+
+
+@pytest.mark.openedx
+def test_get_page_value():
+    """
+    Test `get_page_value()` helper for `page` type of configurations.
+    """
+    current_config = Mock()
+    current_config.get_page_content.return_value = '{"title": "About page"}'
+    with with_current_configs(current_config):
+        page_value = openedx_api.get_page_value('about', {})
+    assert page_value == '{"title": "About page"}'
+    current_config.get_page_content.assert_called_with('about', {})

--- a/tests/test_openedx_test_helpers.py
+++ b/tests/test_openedx_test_helpers.py
@@ -1,0 +1,30 @@
+"""
+Tests for site_config_client.openedx.test_helpers
+"""
+import pytest
+
+try:
+    from site_config_client.openedx.test_helpers import override_site_config
+    from site_config_client.openedx import api as openedx_api
+except ImportError:
+    # Silent import failures for non-Open edX environments.
+    pass
+
+
+@pytest.mark.openedx
+def test_secret_override():
+    """
+    Use `override_site_config` for a `secret` site configuration.
+    """
+    with override_site_config('secret', EMAIL_PASSWORD='test'):
+        assert openedx_api.get_secret_value('EMAIL_PASSWORD') == 'test'
+
+
+@pytest.mark.openedx
+def test_without_overrides_fails():
+    """
+    Test that api fails without overrides due to missing packages in test environment.
+    """
+
+    with pytest.raises(NameError, match='name .configuration_helpers. is not defined'):
+        openedx_api.get_secret_value('EMAIL_PASSWORD')


### PR DESCRIPTION
until we fully migrate out of `site_configuration` when Open edX deprecates it.

closes https://github.com/appsembler/site-configuration-client/issues/59

#### Benefits
  - prepare for deprecating `site_configuration` https://github.com/openedx/platform-roadmap/issues/21
  - allow easier separation of `secret`, `admin` and other settings
  - packages can use these helpers instead of mocking Open edX configuration

#### TODO

 - [x] Use from within `tahoe-auth0`
 - [x] Test in devstack