### PR TITLE
openedx.api: prevent failures in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Note: Update the `Unreleased link` after adding a new release -->
 
-## [Unreleased](https://github.com/appsembler/tahoe-sites/compare/v0.1.4...HEAD)
+## [Unreleased](https://github.com/appsembler/tahoe-sites/compare/v0.1.5...HEAD)
 
-## [0.1.3](https://github.com/appsembler/site-configuration-client/compare/v0.1.3...v0.1.4) - 2022-03-23
+## [0.1.5](https://github.com/appsembler/site-configuration-client/compare/v0.1.5...v0.1.5) - 2022-03-29
+ - `openedx.api` value getters return `default` if current site doesn't exist
+
+## [0.1.4](https://github.com/appsembler/site-configuration-client/compare/v0.1.3...v0.1.4) - 2022-03-23
  - added `openedx.api` for getting individual values for the current site
 
 ## [0.1.3](https://github.com/appsembler/site-configuration-client/compare/v0.1.2...v0.1.3) - 2022-03-17

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='site-configuration-client',
-    version='0.1.4',
+    version='0.1.5',
     description='Python client library for Site Configuration API',
     classifiers=[
         "Intended Audience :: Developers",

--- a/site_config_client/openedx/api.py
+++ b/site_config_client/openedx/api.py
@@ -36,7 +36,9 @@ def get_admin_value(name, default=None, site_configuration=None):
     if not site_configuration:
         site_configuration = get_current_configuration()
 
-    return site_configuration.get_admin_setting(name, default)
+    if site_configuration:
+        return site_configuration.get_admin_setting(name, default)
+    return default
 
 
 def get_secret_value(name, default=None, site_configuration=None):
@@ -45,11 +47,12 @@ def get_secret_value(name, default=None, site_configuration=None):
 
     Proxy for `site_configuration.get_secret_value` until site_configuration is deprecated.
     """
-
     if not site_configuration:
         site_configuration = get_current_configuration()
 
-    return site_configuration.get_secret_value(name, default)
+    if site_configuration:
+        return site_configuration.get_secret_value(name, default)
+    return default
 
 
 def get_setting_value(name, default=None, site_configuration=None):
@@ -61,7 +64,9 @@ def get_setting_value(name, default=None, site_configuration=None):
     if not site_configuration:
         site_configuration = get_current_configuration()
 
-    return site_configuration.get_value(name, default)
+    if site_configuration:
+        return site_configuration.get_value(name, default)
+    return default
 
 
 def get_page_value(name, default=None, site_configuration=None):
@@ -73,4 +78,6 @@ def get_page_value(name, default=None, site_configuration=None):
     if not site_configuration:
         site_configuration = get_current_configuration()
 
-    return site_configuration.get_page_content(name, default)
+    if site_configuration:
+        return site_configuration.get_page_content(name, default)
+    return default

--- a/tests/test_openedx_api.py
+++ b/tests/test_openedx_api.py
@@ -75,3 +75,17 @@ def test_get_page_value():
         page_value = openedx_api.get_page_value('about', {})
     assert page_value == '{"title": "About page"}'
     current_config.get_page_content.assert_called_with('about', {})
+
+
+@pytest.mark.openedx
+@with_current_configs(current_config=None)  # Simulate an environment with no current configuration.
+def test_use_default_on_missing_site_configuration():
+    """
+    Ensure all openedx_api helpers return `default` if `site_configuration` is missing.
+
+    This is useful to return `None` for tests and when running on Open edX's main site.
+    """
+    assert openedx_api.get_secret_value('TEST_SECRET', 'default_secret') == 'default_secret'
+    assert openedx_api.get_admin_value('TEST_CONFIG', 'dummy-default') == 'dummy-default'
+    assert openedx_api.get_page_value('TEST_PAGE', 'dummy_page_content') == 'dummy_page_content'
+    assert openedx_api.get_setting_value('CUSTOMER_ID', 'dummy-customer') == 'dummy-customer'


### PR DESCRIPTION
Use `default` if `get_current_configuration` isn't available


### TODO
  - [x] Add tests