### PR TITLE
attempt to fix pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,16 @@
+import os
 from setuptools import find_packages, setup
+
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
 
 setup(
     name='site-configuration-client',
     version='0.1.6',
     description='Python client library for Site Configuration API',
+    long_description=read('README.rst'),
     classifiers=[
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",


### PR DESCRIPTION
## Attempt to resolve pypi errors

Adding `long_description` setting to resolve pypi errors ([doc](https://pythonhosted.org/an_example_pypi_project/setuptools.html#setting-up-setup-py)).

```
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         No content rendered from RST source.                                   
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
Checking dist/site-configuration-client-0.1.6.tar.gz: PASSED with warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
WARNING  `long_description` missing.  
```