### PR TITLE
pin google requirements to fix py35 incompatible packages

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,8 @@ requests-mock==1.9.3
 tox==3.24.0
 
 
-google-api-core>=1.23.0,<=2.0.1
+google-api-core==1.23.0
 google-cloud==0.34.0
-google-cloud-storage>=1.32.0,<=1.42.3
+google-cloud-storage==1.32.0
+googleapis-common-protos==1.51.0
+protobuf==3.19.4


### PR DESCRIPTION
google aparently isn't following semver, so tox tests stopped working
