### PR TITLE
fix exception when `bucket.get_blob` returns `None`

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,9 +5,4 @@ pytest-cov>=2.12.1,<=3.0.0
 requests-mock==1.9.3
 tox==3.24.0
 
-
-google-api-core==1.23.0
-google-cloud==0.34.0
 google-cloud-storage==1.32.0
-googleapis-common-protos==1.51.0
-protobuf==3.19.4

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name='site-configuration-client',
-    version='0.1.10',
+    version='0.1.11',
     description='Python client library for Site Configuration API',
     long_description=read('README.rst'),
     classifiers=[

--- a/site_config_client/google_cloud_storage.py
+++ b/site_config_client/google_cloud_storage.py
@@ -25,8 +25,11 @@ class GoogleCloudStorage:
         If the file don't exists, it returns `None`.
         """
         blob = self.bucket.get_blob(file_path)
-        try:
-            return blob.download_as_bytes().decode('utf-8')
-        except NotFound:
-            log.warning('File path not found: %s', file_path)
-            return None
+        if blob:
+            try:
+                return blob.download_as_bytes().decode('utf-8')
+            except NotFound:
+                pass
+
+        log.info('File path not found: %s', file_path)
+        return None

--- a/tests/test_google_cloud_storage.py
+++ b/tests/test_google_cloud_storage.py
@@ -1,6 +1,7 @@
 """
 Tests for GoogleCloudStorage
 """
+import logging
 
 from unittest.mock import patch, Mock
 from google.api_core.exceptions import NotFound
@@ -30,7 +31,8 @@ def test_gcp_storage(client_cls):
 
 
 @patch('google.cloud.storage.Client')
-def test_gcp_storage_not_found(client_cls):
+def test_gcp_storage_not_found(client_cls, caplog):
+    caplog.set_level(logging.INFO)
     mock_blob = Mock()
     mock_blob.download_as_bytes.side_effect = NotFound('file not found')
     client_cls.return_value = get_mock_gcp_client(mock_blob)
@@ -40,3 +42,20 @@ def test_gcp_storage_not_found(client_cls):
 
     assert content is None, \
         'If the file not found, the siteconfg.Client should take of this case'
+    assert 'File path not found: some_file.json' in caplog.text
+
+
+@patch('google.cloud.storage.Client')
+def test_gcp_storage_blob_is_none(client_cls, caplog):
+    """
+    Google Cloud Storage returns a `None` blob, ensure this case is handled.
+    """
+    caplog.set_level(logging.INFO)
+    client_cls.return_value = get_mock_gcp_client(mock_blob=None)
+    storage = GoogleCloudStorage('random_bucket_name')
+
+    content = storage.read('some_file.json')
+
+    assert content is None, \
+        'If the file not found, the siteconfg.Client should take of this case'
+    assert 'File path not found: some_file.json' in caplog.text


### PR DESCRIPTION
```
>>> client.read_only_storage.read('omar')
Traceback (most recent call last):
  File "/usr/lib/python3.5/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "site_config_client/google_cloud_storage.py", line 29, in read
    return blob.download_as_bytes().decode('utf-8')
```

### TODO
 - [x] Test on devstack