### PR TITLE
support tier params in create_site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/appsembler/tahoe-sites/compare/v0.2.1...HEAD)
 
+## [0.2.2](https://github.com/appsembler/site-configuration-client/compare/v0.2.1...v0.2.2) - 2022-08-10
+ - `create_site` to accept tier info parameters
 
 ## [0.2.1](https://github.com/appsembler/site-configuration-client/compare/v0.1.12...v0.2.1) - 2022-07-21
  - support studio

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name='site-configuration-client',
-    version='0.2.1',
+    version='0.2.2',
     description='Python client library for Site Configuration API',
     long_description=read('README.rst'),
     classifiers=[

--- a/site_config_client/client.py
+++ b/site_config_client/client.py
@@ -60,11 +60,12 @@ class Client:
                 body=response.content,
             ))
 
-    def create_site(self, domain_name: str, site_uuid=None):
+    def create_site(self, domain_name: str, site_uuid=None, params=None):
         """
         Create a new site.
         """
-        params = {'domain_name': domain_name}
+        params = params or {}
+        params['domain_name'] = domain_name
         if site_uuid:
             params['uuid'] = site_uuid
         url = 'v1/environment/{}/site/'.format(self.environment)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -135,6 +135,30 @@ def test_create_site(site_config_client, requests_mock):
         'API Token passed in Authorization header')
 
 
+def test_create_site_with_params(site_config_client, requests_mock):
+    """
+    Tests that uuid is optional, and `params` can be used.
+    """
+    requests_mock.post(
+        'http://service/v1/environment/staging/site/',
+        json={},
+        headers={'Authorization': '{}'.format(site_config_client.api_token)},
+        status_code=201,
+    )
+    site_config_client.create_site(
+        domain_name='example.com',
+        params={
+            'tier': 'premium',
+        }
+    )
+    history = requests_mock.request_history[0]
+    request_json = json.loads(history.body.decode('utf-8'))
+    assert request_json == {
+        'domain_name': 'example.com',
+        'tier': 'premium',
+    }
+
+
 def test_create_site_with_error(site_config_client, requests_mock):
     headers = {'Authorization': '{}'.format(site_config_client.api_token)}
 


### PR DESCRIPTION
This is needed for the Tahoe 2.0 sites migration command: RED-2536.

### TODO
 - [x] Add tests